### PR TITLE
update_kl_20180911

### DIFF
--- a/R/dima.template.R
+++ b/R/dima.template.R
@@ -55,33 +55,39 @@ build.DIMA.template<-function(data, template.file, method, out.file){
                                             by=c(`SubPlot#`="SubPlot.", colnames(data)[colnames(data) %in% colnames(DIMA.template.header)]))
 
     #Subset to fields in DIMA template
-    data.formatted.header<-data.formatted.header[,colnames(data.formatted.header) %in% colnames(DIMA.template.header)]
+    data.formatted.header<-data.formatted.header[,colnames(data.formatted.header) %in% colnames(DIMA.template.header)]%>% unique()
 
     #Add the Excel formatted names back in
     names(data.formatted.header)<-template.names.header
 
-    ###Build DIMA Detail Table
-
-    DIMA.template.detail<-readxl::read_excel(template.file, col_types = "text", sheet = "SubPlot Species")
+    ###Build DIMA Detail Tables
+    DIMA.template.detail.species<-readxl::read_excel(template.file, col_types = "text", sheet = "SubPlot Species")
+    DIMA.template.detail.abundance<-readxl::read_excel(template.file, col_types = "text", sheet = "Species Abundance")
+    
     #Template names
-    template.names.detail<-names(DIMA.template.detail)
+    template.names.detail.species<-names(DIMA.template.detail.species)
+    template.names.detail.abundance<-names(DIMA.template.detail.abundance)
 
     #Update the  Template Names (e.g., remove spaces)
-    names(DIMA.template.detail)<-names(DIMA.template.detail) %>% gsub(pattern=" ", replacement = "")
-
+    names(DIMA.template.detail.species)<-names(DIMA.template.detail.species) %>% gsub(pattern=" ", replacement = "")
+    names(DIMA.template.detail.abundance)<-names(DIMA.template.detail.abundance) %>% gsub(pattern=" ", replacement = "")
 
     #Join to data
-    data.formatted.detail<-dplyr::full_join(DIMA.template.detail, data,
-                                            by=c(`SubPlot#`="SubPlot.", colnames(data)[colnames(data) %in% colnames(DIMA.template.detail)]))
+    data.formatted.detail.species<-dplyr::full_join(DIMA.template.detail.species, data,
+                                            by=c(`SubPlot#`="SubPlot.", colnames(data)[colnames(data) %in% colnames(DIMA.template.detail.species)]))
+    data.formatted.detail.abundance<-dplyr::full_join(DIMA.template.detail.abundance, data,
+                                            by=c(`SubPlot#`="SubPlot.", colnames(data)[colnames(data) %in% colnames(DIMA.template.detail.abundance)]))
 
     #Subset to fields in DIMA template
-    data.formatted.detail<-data.formatted.detail[, colnames(data.formatted.detail) %in% colnames(DIMA.template.detail)]
+    data.formatted.detail.species<-data.formatted.detail.species[, colnames(data.formatted.detail.species) %in% colnames(DIMA.template.detail.species)]
+    data.formatted.detail.abundance<-data.formatted.detail.abundance[, colnames(data.formatted.detail.abundance) %in% colnames(DIMA.template.detail.abundance)]
 
     #Add the Excel formatted names back in
-    names(data.formatted.detail)<-template.names.detail
+    names(data.formatted.detail.species)<-template.names.detail.species
+    names(data.formatted.detail.abundance)<-template.names.detail.abundance
 
     #Create list
-    data.formatted<-list("SpecRich SubPlots"=data.formatted.header, "SubPlot Species"=data.formatted.detail)
+    data.formatted<-list("SpecRich SubPlots"=data.formatted.header, "SubPlot Species"=data.formatted.detail.species, "SpeciesAbundance"=data.formatted.detail.abundance)
 
     #Write out detail table
     openxlsx::write.xlsx(x = data.formatted, file=out.file)

--- a/R/xlsx2R.R
+++ b/R/xlsx2R.R
@@ -31,7 +31,7 @@ map.excel<-function(excel.file, reference.tall, field, format){
   } else if(any(is.na(cell.ref))){
     data<-NA
   } else if (field=="Date"){
-    data<-tryCatch(readxl::read_excel(path=excel.file, sheet=format, range=cell.ref, col_types = "date", col_names=FALSE)[[1]]%>% as.character, error=function(e) return(NA))
+    data<-tryCatch(readxl::read_excel(path=excel.file,sheet=format, range=cell.ref, col_types = "date", col_names=FALSE)[[1]]%>% as.character, error=function(e) return(NA))
   } else{
     #Define rows
     #rows<-gsub(pattern="[[:alpha:]]", "", x=cell.ref)%>% unique()%>%

--- a/R/xlsx2R.R
+++ b/R/xlsx2R.R
@@ -31,23 +31,26 @@ map.excel<-function(excel.file, reference.tall, field, format){
   } else if(any(is.na(cell.ref))){
     data<-NA
   } else if (field=="Date"){
-    data<-tryCatch(readxl::read_excel(path=excel.file,sheet =format,range=cell.ref, col_types = "date", col_names=FALSE)[[1]]%>% as.character, error=function(e) return(NA))
+    data<-tryCatch(readxl::read_excel(path=excel.file, sheet=format, range=cell.ref, col_types = "date", col_names=FALSE)[[1]]%>% as.character, error=function(e) return(NA))
   } else{
     #Define rows
-    rows<-gsub(pattern="[[:alpha:]]", "", x=cell.ref)%>% unique()%>%
-      strsplit(., split = ":")%>% unlist()%>% as.numeric
-    rows<-seq(min(rows), max(rows))
+    #rows<-gsub(pattern="[[:alpha:]]", "", x=cell.ref)%>% unique()%>%
+    #  strsplit(., split = ":")%>% unlist()%>% as.numeric
+    #rows<-seq(min(rows), max(rows))
 
     #Define cells
-    cols<-strsplit(cell.ref, split = ":")%>% unlist() %>% openxlsx::convertFromExcelRef() %>% unique()
+    #cols<-strsplit(cell.ref, split = ":")%>% unlist() %>% openxlsx::convertFromExcelRef() %>% unique()
 
     #Read in row/column specific data from R
-    data<-tryCatch(openxlsx::read.xlsx(excel.file, sheet=format, rows=rows, cols=cols, colNames=FALSE, skipEmptyRows=FALSE)%>% unlist(),
-                   warning=function(w) return(NA))
+    data<-tryCatch(lapply(X=cell.ref,FUN=function(X){
+      readxl::read_excel(path=excel.file, sheet=format, range=(X), col_names=FALSE)%>%data.frame()}), warning=function(w) return(NA))
+    data<-lapply(X=data,FUN=function(X){
+      if(!nrow(X)>0){X<-NA}
+      else{X<-X}
+      })%>%data.frame()%>%unlist()
   }
 
   return(data)
-
 }
 
 #'@export


### PR DESCRIPTION
In the function map.excel, for valid excel references other than field "Date", openxlsx::read.xlsx skips blank rows at the top. Using it caused points in different columns to get offset if a lower layer only had a few codes, since the first non-blank cell would be recorded as though it were at point #1. Since readxl::read_excel reads exactly the cell range(s) specified, including leading blank rows, it is a better option even though it requires a bit more massaging after reading in the data.